### PR TITLE
Update tests for Symfony 2.8/3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     - php: hhvm
 
 env:
-  - SYMFONY_VERSION='2.7.*'
+  - SYMFONY_VERSION='2.8.*'
   - SYMFONY_VERSION='3.0.*'
 
 before_script:

--- a/Tests/Form/Extension/ChoiceList/LocaleChoiceListTest.php
+++ b/Tests/Form/Extension/ChoiceList/LocaleChoiceListTest.php
@@ -95,15 +95,11 @@ class LocaleChoiceListTest extends \PHPUnit_Framework_TestCase
                 ->will($this->returnValue(array('de', 'nl', 'en')));
 
         $list = new LocaleChoiceList($information);
-        $preferredResult = $list->getPreferredViews();
-        $remainingResults = $list->getRemainingViews();
+        $preferredResult = $list->getPreferredChoices();
 
-        $this->assertEquals('de', $preferredResult[0]->value);
-        $this->assertEquals('nl', $preferredResult[1]->value);
-        $this->assertEquals('en', $preferredResult[2]->value);
-
-        $this->assertEquals('fr', $remainingResults[0]->value);
-        $this->assertEquals('tr', $remainingResults[1]->value);
+        $this->assertEquals('de', $preferredResult[0]);
+        $this->assertEquals('nl', $preferredResult[1]);
+        $this->assertEquals('en', $preferredResult[2]);
     }
 
     public function getLocaleInformation()

--- a/Tests/Form/Extension/Type/LocaleTypeTest.php
+++ b/Tests/Form/Extension/Type/LocaleTypeTest.php
@@ -16,7 +16,7 @@ use Lunetics\LocaleBundle\Form\Extension\Type\LocaleType;
  */
 class LocaleTypeTest extends \PHPUnit_Framework_TestCase
 {
-    public function testSetDefaultOptions()
+    public function testConfigureOptions()
     {
         $choiceList = $this->getMockLocaleChoiceList();
 
@@ -27,7 +27,7 @@ class LocaleTypeTest extends \PHPUnit_Framework_TestCase
             ->with(array('choice_list' => $choiceList));
 
         $type = new LocaleType($choiceList);
-        $type->setDefaultOptions($resolver);
+        $type->configureOptions($resolver);
     }
 
     public function testGetParent()
@@ -41,7 +41,7 @@ class LocaleTypeTest extends \PHPUnit_Framework_TestCase
     {
         $type = new LocaleType($this->getMockLocaleChoiceList());
 
-        $this->assertEquals('lunetics_locale', $type->getName());
+        $this->assertEquals('lunetics_locale', $type->getBlockPrefix());
     }
 
     protected function getMockLocaleChoiceList()

--- a/Tests/Form/Extension/Type/LocaleTypeTest.php
+++ b/Tests/Form/Extension/Type/LocaleTypeTest.php
@@ -24,7 +24,7 @@ class LocaleTypeTest extends \PHPUnit_Framework_TestCase
         $resolver
             ->expects($this->once())
             ->method('setDefaults')
-            ->with(array('choice_list' => $choiceList));
+            ->with(array('choices' => null, 'preferred_choices' => null));
 
         $type = new LocaleType($choiceList);
         $type->configureOptions($resolver);
@@ -34,7 +34,7 @@ class LocaleTypeTest extends \PHPUnit_Framework_TestCase
     {
         $type = new LocaleType($this->getMockLocaleChoiceList());
 
-        $this->assertEquals('choice', $type->getParent());
+        $this->assertEquals('Symfony\\Component\\Form\\Extension\\Core\\Type\\ChoiceType', $type->getParent());
     }
 
     public function testGetName()

--- a/composer.json
+++ b/composer.json
@@ -17,16 +17,16 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.5.9",
-        "symfony/framework-bundle": "^2.7|^3.0",
-        "symfony/yaml": "^2.7|^3.0",
-        "symfony/locale": "^2.7|^3.0",
-        "symfony/validator": "^2.7|^3.0",
+        "symfony/framework-bundle": "^2.8|^3.0",
+        "symfony/yaml": "^2.8|^3.0",
+        "symfony/locale": "^2.8|^3.0",
+        "symfony/validator": "^2.8|^3.0",
         "psr/log": "~1.0"
     },
     "require-dev": {
-        "twig/twig": "1.*|2.*",
         "ext-intl": "*",
-        "symfony/form": "^2.7|^3.0"
+        "twig/twig": "1.*|2.*",
+        "symfony/form": "^2.8|^3.0"
     },
     "suggest": {
         "ext-intl": "Needed for displaying the country name in the locale language"


### PR DESCRIPTION
@lunetics and I had a irc session today and I updated the tests for Symfony 2.8 / 3.0.

There are still 4 failures: http://paste.ubuntu.com/15051410/

We’ll look into how to solve them. I don’t really know if these transformations from nl -> Dutch, de -> German etc are desired.
